### PR TITLE
add job name

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build:
+    name: rust test
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
A job name is needed to show up a job as status checker.