### PR TITLE
handle multiple closing ids

### DIFF
--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -164,7 +164,7 @@ mod tests {
 
         let table = [
             TestCase {
-                name: String::from("nominal: with priority and cost"),
+                name: String::from("normal: with priority and cost"),
                 args: Args {
                     title: String::from("title1"),
                     priority: Some(Priority(100)),
@@ -180,7 +180,7 @@ mod tests {
                 },
             },
             TestCase {
-                name: String::from("nominal: withtout priority and cost"),
+                name: String::from("normal: withtout priority and cost"),
                 args: Args {
                     title: String::from("title2"),
                     priority: None,
@@ -273,7 +273,7 @@ mod tests {
         }
 
         let table = [TestCase {
-            name: String::from("nominal: with priority and cost"),
+            name: String::from("normal: with priority and cost"),
             args: Args {
                 id: ID(1),
                 title: String::from("title1"),

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -347,5 +347,5 @@ pub trait ITaskRepository {
     fn find_opening(&self) -> Result<Vec<Task>>;
     fn fetch_all(&self) -> Result<Vec<Task>>;
     fn add(&self, a_task: Task) -> Result<ID>;
-    fn update(&self, a_task: Task) -> Result<ID>;
+    fn update(&self, a_task: Task) -> Result<()>;
 }

--- a/src/infra/sqlite/task_repository.rs
+++ b/src/infra/sqlite/task_repository.rs
@@ -256,7 +256,7 @@ mod tests {
         }
 
         let table = [TestCase {
-            name: String::from("nominal: close"),
+            name: String::from("normal: close"),
             given: Task::new(
                 "hoge".to_owned(),
                 Some(Priority::new(2)),
@@ -327,7 +327,7 @@ mod tests {
                 },
             },
             TestCase {
-                name: String::from("anominal: not found task"),
+                name: String::from("abnormal: not found task"),
                 args: Args {
                     make_id: |id| ID::new(id.get() + 100),
                 },
@@ -389,12 +389,12 @@ mod tests {
                 ],
             },
             TestCase {
-                name: String::from("nominal: empty table"),
+                name: String::from("normal: empty table"),
                 given: Vec::new(),
                 want: Vec::new(),
             },
             TestCase {
-                name: String::from("nominal: all closed"),
+                name: String::from("normal: all closed"),
                 given: vec![
                     make_task(1, true),
                     make_task(2, true),
@@ -449,7 +449,7 @@ mod tests {
                 ],
             },
             TestCase {
-                name: String::from("nominal: empty table"),
+                name: String::from("normal: empty table"),
                 given: Vec::new(),
                 want: Vec::new(),
             },

--- a/src/infra/sqlite/task_repository.rs
+++ b/src/infra/sqlite/task_repository.rs
@@ -158,7 +158,7 @@ impl ITaskRepository for TaskRepository {
     }
 
     /// Update a Task.
-    fn update(&self, a_task: Task) -> Result<ID> {
+    fn update(&self, a_task: Task) -> Result<()> {
         let mut stmt = self.conn.prepare(
             "UPDATE tasks SET
                 title = ?1,
@@ -169,7 +169,7 @@ impl ITaskRepository for TaskRepository {
              where id = ?6",
         )?;
 
-        let rowid = stmt.insert(rusqlite::params![
+        stmt.insert(rusqlite::params![
             a_task.title(),
             a_task.is_closed(),
             a_task.priority().get(),
@@ -178,7 +178,7 @@ impl ITaskRepository for TaskRepository {
             a_task.id().get(),
         ])?;
 
-        Ok(ID::new(rowid))
+        Ok(())
     }
 }
 
@@ -286,8 +286,8 @@ mod tests {
         task_repository.create_table_if_not_exists().unwrap();
 
         for test_case in table {
-            task_repository.add(test_case.given).unwrap();
-            let id = task_repository.update(test_case.args.task).unwrap();
+            let id = task_repository.add(test_case.given).unwrap();
+            task_repository.update(test_case.args.task).unwrap();
             assert_eq!(
                 task_repository.find_by_id(id).unwrap(),
                 test_case.want,

--- a/src/presentation/command/cli.rs
+++ b/src/presentation/command/cli.rs
@@ -31,7 +31,7 @@ enum SubCommands {
     #[clap(arg_required_else_help = true)]
     Close {
         /// id of the task.
-        id: i64,
+        ids: Vec<i64>,
     },
     /// list tasks.
     List {},
@@ -75,10 +75,20 @@ impl Cli {
                 };
                 self.add_task_usecase.execute(input).unwrap();
             }
-            SubCommands::Close { id } => {
-                self.close_task_usecase
-                    .execute(CloseTaskUseCaseInput { id: id.to_owned() })
-                    .unwrap();
+            SubCommands::Close { ids } => {
+                for id in ids {
+                    match self
+                        .close_task_usecase
+                        .execute(CloseTaskUseCaseInput { id: id.to_owned() })
+                    {
+                        Ok(r_id) => {
+                            println!("Close the task for id `{}`.", r_id.get())
+                        }
+                        Err(err) => {
+                            eprintln!("Failed to closing the task: {}", err)
+                        }
+                    }
+                }
             }
             SubCommands::List {} => {
                 let task_dto = self

--- a/src/presentation/command/cli.rs
+++ b/src/presentation/command/cli.rs
@@ -6,13 +6,14 @@ use crate::usecase::add_task_usecase::{AddTaskUseCase, AddTaskUseCaseInput};
 use crate::usecase::close_task_usecase::{CloseTaskUseCase, CloseTaskUseCaseInput};
 use crate::usecase::list_task_usecase::{ListTaskUseCase, ListTaskUseCaseInput};
 
-/// A fictional versioning CLI
+/// Command has subcommands.
 #[derive(Parser)]
 struct Command {
     #[clap(subcommand)]
     command: SubCommands,
 }
 
+/// Subcommands define cli subcommands.
 #[derive(Subcommand)]
 enum SubCommands {
     /// add a task.
@@ -37,6 +38,7 @@ enum SubCommands {
     List {},
 }
 
+/// Cli has structs to execute usecases.
 pub struct Cli {
     add_task_usecase: AddTaskUseCase,
     close_task_usecase: CloseTaskUseCase,
@@ -45,6 +47,7 @@ pub struct Cli {
 }
 
 impl Cli {
+    /// construct Cli.
     pub fn new(
         add_task_usecase: AddTaskUseCase,
         close_task_usecase: CloseTaskUseCase,
@@ -59,6 +62,7 @@ impl Cli {
         }
     }
 
+    /// handle user input.
     pub fn handle(&mut self) {
         let args = Command::parse();
 

--- a/src/presentation/command/cli.rs
+++ b/src/presentation/command/cli.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use std::io;
+use std::{io, process};
 
 use crate::presentation::printer::table::TablePrinter;
 use crate::usecase::add_task_usecase::{AddTaskUseCase, AddTaskUseCaseInput};
@@ -76,6 +76,7 @@ impl Cli {
                 self.add_task_usecase.execute(input).unwrap();
             }
             SubCommands::Close { ids } => {
+                let mut is_all_success = true;
                 for id in ids {
                     match self
                         .close_task_usecase
@@ -85,9 +86,14 @@ impl Cli {
                             println!("Close the task for id `{}`.", r_id.get())
                         }
                         Err(err) => {
-                            eprintln!("Failed to closing the task: {}", err)
+                            is_all_success = false;
+                            eprintln!("Failed to closing the task: {}.", err)
                         }
                     }
+                }
+
+                if !is_all_success {
+                    process::exit(1);
                 }
             }
             SubCommands::List {} => {

--- a/src/presentation/printer/table.rs
+++ b/src/presentation/printer/table.rs
@@ -52,12 +52,12 @@ mod tests {
 
         let table = [
             TestCase {
-                name: String::from("nominal: with priority and cost"),
+                name: String::from("normal: with priority and cost"),
                 args: Args { tasks: vec![] },
                 want: String::from("ID  Title  Priority  Cost\n"),
             },
             TestCase {
-                name: String::from("nominal: with priority and cost"),
+                name: String::from("normal: with priority and cost"),
                 args: Args {
                     tasks: vec![
                         TaskDTO {

--- a/src/usecase/add_task_usecase.rs
+++ b/src/usecase/add_task_usecase.rs
@@ -52,7 +52,7 @@ mod tests {
 
         let table = [
             TestCase {
-                name: String::from("nominal: with priority and cost"),
+                name: String::from("normal: with priority and cost"),
                 args: Args {
                     input: AddTaskUseCaseInput {
                         title: String::from("title1"),
@@ -67,7 +67,7 @@ mod tests {
                 ),
             },
             TestCase {
-                name: String::from("nominal: without priority and cost"),
+                name: String::from("normal: without priority and cost"),
                 args: Args {
                     input: AddTaskUseCaseInput {
                         title: String::from("title2"),

--- a/src/usecase/close_task_usecase.rs
+++ b/src/usecase/close_task_usecase.rs
@@ -29,7 +29,7 @@ impl CloseTaskUseCase {
         let id = t.id();
 
         if t.is_closed() {
-            Err(UseCaseError::AlreadyClosed(id.get().to_owned()))?;
+            return Err(UseCaseError::AlreadyClosed(id.get().to_owned()).into())
         }
 
         t.close();

--- a/src/usecase/error.rs
+++ b/src/usecase/error.rs
@@ -24,7 +24,7 @@ mod tests {
     fn test_already_closed() {
         assert_eq!(
             UseCaseError::AlreadyClosed(3).to_string(),
-            "the task for id `3` has already be closed".to_owned()
+            "the task for id `3` has already been closed".to_owned()
         );
     }
 }

--- a/src/usecase/error.rs
+++ b/src/usecase/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 pub enum UseCaseError {
     #[error("the task for id `{0}` is not found")]
     NotFound(i64),
-    #[error("the task for id `{0}` has already be closed")]
+    #[error("the task for id `{0}` has already been closed")]
     AlreadyClosed(i64),
 }
 

--- a/src/usecase/error.rs
+++ b/src/usecase/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum UseCaseError {
     #[error("the task for id `{0}` is not found")]
     NotFound(i64),
+    #[error("the task for id `{0}` has already be closed")]
+    AlreadyClosed(i64),
 }
 
 #[cfg(test)]
@@ -15,6 +17,14 @@ mod tests {
         assert_eq!(
             UseCaseError::NotFound(2).to_string(),
             "the task for id `2` is not found".to_owned()
+        );
+    }
+
+    #[test]
+    fn test_already_closed() {
+        assert_eq!(
+            UseCaseError::AlreadyClosed(3).to_string(),
+            "the task for id `3` has already be closed".to_owned()
         );
     }
 }

--- a/src/usecase/list_task_usecase.rs
+++ b/src/usecase/list_task_usecase.rs
@@ -88,7 +88,7 @@ mod tests {
         }
 
         let table = [TestCase {
-            name: String::from("nominal: with priority and cost"),
+            name: String::from("normal: with priority and cost"),
             given: vec![
                 make_task(1, false),
                 make_task(2, false),


### PR DESCRIPTION
Users can close multiple tasks with bellow command.

```
taskmr close 1 2 3
```

Then, users can get 2 type errors.

* NotFound: when users specify the id which is not exist in db
* AlreadyClosed: when users specify the id which represent the task that has already been closed